### PR TITLE
feat: optimization of the async helper

### DIFF
--- a/wechaty-puppet/helper/async.go
+++ b/wechaty-puppet/helper/async.go
@@ -31,6 +31,7 @@ type (
 	Task func() (interface{}, error)
 )
 
+// NewAsync ...
 func NewAsync(maxWorkerNum int) IAsync {
 	if maxWorkerNum <= 0 {
 		maxWorkerNum = DefaultWorkerNum
@@ -79,7 +80,7 @@ func (a *async) Result() []AsyncResult {
 	idx := 0
 	for v := range resultChan {
 		result[idx] = v
-		idx += 1
+		idx++
 	}
 	return result
 }

--- a/wechaty-puppet/helper/async.go
+++ b/wechaty-puppet/helper/async.go
@@ -44,9 +44,6 @@ func NewAsync(maxWorkerNum int) IAsync {
 }
 
 func (a *async) AddTask(task Task) {
-	if a.tasks == nil {
-		a.tasks = make([]Task, 0)
-	}
 	a.tasks = append(a.tasks, task)
 }
 

--- a/wechaty-puppet/helper/async.go
+++ b/wechaty-puppet/helper/async.go
@@ -43,7 +43,6 @@ func NewAsync(maxWorkerNum int) IAsync {
 
 func (a *async) AddTask(task Task) {
 	a.tasks = append(a.tasks, task)
-
 }
 
 func (a *async) Result() []AsyncResult {

--- a/wechaty-puppet/helper/async.go
+++ b/wechaty-puppet/helper/async.go
@@ -76,11 +76,9 @@ func (a *async) Result() []AsyncResult {
 		a.tasks = make([]Task, 0)
 	}()
 
-	result := make([]AsyncResult, taskNum)
-	idx := 0
+	result := make([]AsyncResult, 0, taskNum)
 	for v := range resultChan {
-		result[idx] = v
-		idx++
+		result = append(result, v)
 	}
 	return result
 }


### PR DESCRIPTION
I did some updates on the `async helper`:
1. `workerNum ` -> `maxWorkerNum `, just allocate `number of tasks` tasks if the `number of tasks`is smaller than `maxWorkerNum`.
2. `wg` can be a local variable.
3. clean `tasks []Task` after calling `Result()`, It's intend to make the `async helper` reusable.