### PR TITLE
message adapter

### DIFF
--- a/wechaty-puppet/helper/parase_recalled_msg.go
+++ b/wechaty-puppet/helper/parase_recalled_msg.go
@@ -1,7 +1,7 @@
 package helper
 
 import (
-    "encoding/xml"
+	"encoding/xml"
 )
 
 //<sysmsg type="revokemsg">
@@ -15,27 +15,27 @@ import (
 
 // RecalledMsg 撤回消息的 xml 结构体
 type RecalledMsg struct {
-    XMLName   xml.Name `xml:"sysmsg"`
-    Text      string   `xml:",chardata"`
-    Type      string   `xml:"type,attr"`
-    Revokemsg struct {
-        Text       string `xml:",chardata"`
-        Session    string `xml:"session"`
-        Msgid      string `xml:"msgid"`
-        Newmsgid   string `xml:"newmsgid"`
-        Replacemsg string `xml:"replacemsg"`
-    } `xml:"revokemsg"`
+	XMLName   xml.Name `xml:"sysmsg"`
+	Text      string   `xml:",chardata"`
+	Type      string   `xml:"type,attr"`
+	Revokemsg struct {
+		Text       string `xml:",chardata"`
+		Session    string `xml:"session"`
+		Msgid      string `xml:"msgid"`
+		Newmsgid   string `xml:"newmsgid"`
+		Replacemsg string `xml:"replacemsg"`
+	} `xml:"revokemsg"`
 }
 
-// ParseRecalledId 从 xml 中解析撤回的原始消息id
-func ParseRecalledId(raw string) string {
-    msg := &RecalledMsg{}
-    err := xml.Unmarshal([]byte(raw), msg)
-    if err != nil {
-        return raw
-    }
-    if msg.Revokemsg.Newmsgid != "" {
-        return msg.Revokemsg.Newmsgid
-    }
-    return raw
+// ParseRecalledID 从 xml 中解析撤回的原始消息id
+func ParseRecalledID(raw string) string {
+	msg := &RecalledMsg{}
+	err := xml.Unmarshal([]byte(raw), msg)
+	if err != nil {
+		return raw
+	}
+	if msg.Revokemsg.Newmsgid != "" {
+		return msg.Revokemsg.Newmsgid
+	}
+	return raw
 }

--- a/wechaty-puppet/helper/parase_recalled_msg.go
+++ b/wechaty-puppet/helper/parase_recalled_msg.go
@@ -1,0 +1,41 @@
+package helper
+
+import (
+    "encoding/xml"
+)
+
+//<sysmsg type="revokemsg">
+//<revokemsg>
+//<session>wxid_qswi83jdiiw2</session>
+//<msgid>12543453</msgid>
+//<newmsgid>500043327888834838</newmsgid> // 元消息id
+//<replacemsg><![CDATA["xxx" 撤回了一条消息]]></replacemsg>
+//</revokemsg>
+//</sysmsg>
+
+// RecalledMsg 撤回消息的 xml 结构体
+type RecalledMsg struct {
+    XMLName   xml.Name `xml:"sysmsg"`
+    Text      string   `xml:",chardata"`
+    Type      string   `xml:"type,attr"`
+    Revokemsg struct {
+        Text       string `xml:",chardata"`
+        Session    string `xml:"session"`
+        Msgid      string `xml:"msgid"`
+        Newmsgid   string `xml:"newmsgid"`
+        Replacemsg string `xml:"replacemsg"`
+    } `xml:"revokemsg"`
+}
+
+// ParseRecalledId 从 xml 中解析撤回的原始消息id
+func ParseRecalledId(raw string) string {
+    msg := &RecalledMsg{}
+    err := xml.Unmarshal([]byte(raw), msg)
+    if err != nil {
+        return raw
+    }
+    if msg.Revokemsg.Newmsgid != "" {
+        return msg.Revokemsg.Newmsgid
+    }
+    return raw
+}

--- a/wechaty-puppet/message_adapter.go
+++ b/wechaty-puppet/message_adapter.go
@@ -12,6 +12,7 @@ var rawMsgAdapter = RawMsgAdapter{}
 var unknownMsgAdapter = UnknownMsgAdapter{}
 var recalledMsgAdapter = RecalledMsgAdapter{}
 
+// MsgAdapter 消息适配器
 type MsgAdapter interface {
 	Handle(payload *schemas.MessagePayload)
 }
@@ -27,26 +28,32 @@ func NewMsgAdapter(msgType schemas.MessageType) MsgAdapter {
 	return rawMsgAdapter
 }
 
+// RawMsgAdapter 不需要处理的消息
 type RawMsgAdapter struct{}
 
+// Handle ~
 func (r RawMsgAdapter) Handle(msg *schemas.MessagePayload) {
 	return
 }
 
+// UnknownMsgAdapter Unknown 类型的消息适配器
 type UnknownMsgAdapter struct{}
 
+// Handle 对 Unknown 类型的消息做适配
 func (u UnknownMsgAdapter) Handle(payload *schemas.MessagePayload) {
 	// 有些消息，puppet 服务端没有解析出来，这里尝试解析
 	helper.FixUnknownMessage(payload)
 }
 
+// RecalledMsgAdapter 撤回类型的消息适配器
 type RecalledMsgAdapter struct{}
 
+// Handle padlocal 返回的是 xml，需要解析出 msgId
 func (r RecalledMsgAdapter) Handle(payload *schemas.MessagePayload) {
 	if numRegex.MatchString(payload.Text) {
 		return
 	}
 	// padlocal 返回的是 xml，需要解析出 msgId
 	// https://github.com/wechaty/go-wechaty/issues/87
-	payload.Text = helper.ParseRecalledId(payload.Text)
+	payload.Text = helper.ParseRecalledID(payload.Text)
 }

--- a/wechaty-puppet/message_adapter.go
+++ b/wechaty-puppet/message_adapter.go
@@ -1,0 +1,52 @@
+package wechatypuppet
+
+import (
+	"github.com/wechaty/go-wechaty/wechaty-puppet/helper"
+	"github.com/wechaty/go-wechaty/wechaty-puppet/schemas"
+	"regexp"
+)
+
+var numRegex = regexp.MustCompile(`^\d+$`)
+
+var rawMsgAdapter = RawMsgAdapter{}
+var unknownMsgAdapter = UnknownMsgAdapter{}
+var recalledMsgAdapter = RecalledMsgAdapter{}
+
+type MsgAdapter interface {
+	Handle(payload *schemas.MessagePayload)
+}
+
+// NewMsgAdapter 各种 puppet 返回的消息有出入，这里做统一
+func NewMsgAdapter(msgType schemas.MessageType) MsgAdapter {
+	switch msgType {
+	case schemas.MessageTypeUnknown:
+		return unknownMsgAdapter
+	case schemas.MessageTypeRecalled:
+		return recalledMsgAdapter
+	}
+	return rawMsgAdapter
+}
+
+type RawMsgAdapter struct{}
+
+func (r RawMsgAdapter) Handle(msg *schemas.MessagePayload) {
+	return
+}
+
+type UnknownMsgAdapter struct{}
+
+func (u UnknownMsgAdapter) Handle(payload *schemas.MessagePayload) {
+	// 有些消息，puppet 服务端没有解析出来，这里尝试解析
+	helper.FixUnknownMessage(payload)
+}
+
+type RecalledMsgAdapter struct{}
+
+func (r RecalledMsgAdapter) Handle(payload *schemas.MessagePayload) {
+	if numRegex.MatchString(payload.Text) {
+		return
+	}
+	// padlocal 返回的是 xml，需要解析出 msgId
+	// https://github.com/wechaty/go-wechaty/issues/87
+	payload.Text = helper.ParseRecalledId(payload.Text)
+}

--- a/wechaty-puppet/puppet.go
+++ b/wechaty-puppet/puppet.go
@@ -247,10 +247,10 @@ func (p *Puppet) MessagePayload(messageID string) (*schemas.MessagePayload, erro
 	if err != nil {
 		return nil, err
 	}
-	// 有些消息，puppet 服务端没有解析出来，这里尝试解析
-	if payload.Type == schemas.MessageTypeUnknown {
-		helper.FixUnknownMessage(payload)
-	}
+
+	// 对 puppet 实现方返回的消息做统一处理
+	NewMsgAdapter(payload.Type).Handle(payload)
+
 	p.cacheMessagePayload.Add(messageID, payload)
 	return payload, nil
 }


### PR DESCRIPTION
puppet padlocal 撤回消息返回的是 xml，在 padlocal 未修复之前，go-wechaty 做一层适配，解析出撤回消息的原始id