### PR TITLE
feat(location): support location msg

### DIFF
--- a/wechaty-puppet-mock/puppet_mock.go
+++ b/wechaty-puppet-mock/puppet_mock.go
@@ -12,6 +12,16 @@ type PuppetMock struct {
 	*wechatyPuppet.Puppet
 }
 
+func (p *PuppetMock) MessageLocation(messageID string) (*schemas.LocationPayload, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p *PuppetMock) MessageSendLocation(conversationID string, payload *schemas.LocationPayload) (string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func NewPuppetMock(option wechatyPuppet.Option) (*PuppetMock, error) {
 	puppetAbstract, err := wechatyPuppet.NewPuppet(option)
 	if err != nil {

--- a/wechaty-puppet-service/puppet_service.go
+++ b/wechaty-puppet-service/puppet_service.go
@@ -594,6 +594,52 @@ func (p *PuppetService) MessageFile(id string) (*filebox.FileBox, error) {
 	return NewFileBoxFromMessageFileStream(response)
 }
 
+// MessageLocation get location payload
+func (p *PuppetService) MessageLocation(messageID string) (*schemas.LocationPayload, error) {
+	log.Tracef("PuppetService MessageLocation(%s)\n", messageID)
+
+	response, err := p.grpcClient.MessageLocation(context.Background(), &pbwechatypuppet.MessageLocationRequest{
+		Id: messageID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if response.Location == nil {
+		return &schemas.LocationPayload{
+			Address: "NOADDRESS",
+			Name:    "NONAME",
+		}, nil
+	}
+	return &schemas.LocationPayload{
+		Accuracy:  response.Location.Accuracy,
+		Address:   response.Location.Address,
+		Latitude:  response.Location.Latitude,
+		Longitude: response.Location.Longitude,
+		Name:      response.Location.Name,
+	}, nil
+}
+
+// MessageSendLocation send location
+func (p *PuppetService) MessageSendLocation(conversationID string, payload *schemas.LocationPayload) (string, error) {
+	log.Tracef("PuppetService MessageSendLocation(%s, %+v)\n", conversationID, payload)
+
+	response, err := p.grpcClient.MessageSendLocation(context.Background(), &pbwechatypuppet.MessageSendLocationRequest{
+		ConversationId: conversationID,
+		Location: &pbwechatypuppet.LocationPayload{
+			Accuracy:  payload.Accuracy,
+			Address:   payload.Address,
+			Latitude:  payload.Latitude,
+			Longitude: payload.Longitude,
+			Name:      payload.Name,
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return response.Id, nil
+}
+
 // MessageRawPayload ...
 func (p *PuppetService) MessageRawPayload(id string) (*schemas.MessagePayload, error) {
 	log.Tracef("PuppetService MessagePayload(%s)\n", id)

--- a/wechaty-puppet/puppet.go
+++ b/wechaty-puppet/puppet.go
@@ -31,6 +31,8 @@ type iPuppet interface {
 	MessageSendMiniProgram(conversationID string, miniProgramPayload *schemas.MiniProgramPayload) (string, error)
 	MessageRecall(messageID string) (bool, error)
 	MessageFile(id string) (*filebox.FileBox, error)
+	MessageLocation(messageID string) (*schemas.LocationPayload, error)
+	MessageSendLocation(conversationID string, payload *schemas.LocationPayload) (string, error)
 	MessageRawPayload(id string) (*schemas.MessagePayload, error)
 	MessageSendText(conversationID string, text string, mentionIDList ...string) (string, error)
 	MessageSendFile(conversationID string, fileBox *filebox.FileBox) (string, error)

--- a/wechaty-puppet/schemas/location.go
+++ b/wechaty-puppet/schemas/location.go
@@ -1,0 +1,9 @@
+package schemas
+
+type LocationPayload struct {
+	Accuracy  float32 `json:"accuracy"`  // Estimated horizontal accuracy of this location, radial, in meters. (same as Android & iOS API)
+	Address   string  `json:"address"`   // 北京市北京市海淀区45 Chengfu Rd
+	Latitude  float64 `json:"latitude"`  // 39.995120999999997
+	Longitude float64 `json:"longitude"` // 116.3341
+	Name      string  `json:"name"`      // 东升乡人民政府(海淀区成府路45号)
+}

--- a/wechaty-puppet/schemas/url_link.go
+++ b/wechaty-puppet/schemas/url_link.go
@@ -3,13 +3,13 @@ package schemas
 import "encoding/json"
 
 type UrlLinkPayload struct {
-  Description  string `json:"description"`
-  ThumbnailUrl string `json:"thumbnailUrl"`
-  Title        string `json:"title"`
-  Url          string `json:"url"`
+	Description  string `json:"description"`
+	ThumbnailUrl string `json:"thumbnailUrl"`
+	Title        string `json:"title"`
+	Url          string `json:"url"`
 }
 
 func (u *UrlLinkPayload) ToJson() string {
-  b, _ := json.Marshal(u)
-  return string(b)
+	b, _ := json.Marshal(u)
+	return string(b)
 }

--- a/wechaty/user/location.go
+++ b/wechaty/user/location.go
@@ -1,0 +1,44 @@
+package user
+
+import (
+	"fmt"
+	"github.com/wechaty/go-wechaty/wechaty-puppet/schemas"
+)
+
+type Location struct {
+	payload *schemas.LocationPayload
+}
+
+func NewLocation(payload *schemas.LocationPayload) *Location {
+	return &Location{
+		payload: payload,
+	}
+}
+
+func (l *Location) Payload() schemas.LocationPayload {
+	return *l.payload
+}
+
+func (l *Location) String() string {
+	return fmt.Sprintf("Location<%s>", l.payload.Name)
+}
+
+func (l *Location) Address() string {
+	return l.payload.Address
+}
+
+func (l *Location) Latitude() float64 {
+	return l.payload.Latitude
+}
+
+func (l *Location) longitude() float64 {
+	return l.payload.Longitude
+}
+
+func (l *Location) Name() string {
+	return l.payload.Name
+}
+
+func (l *Location) Accuracy() float32 {
+	return l.payload.Accuracy
+}


### PR DESCRIPTION
support location msg
```
message.ToLocation()

message.Say(user.NewLocation(&schemas.LocationPayload{
		Accuracy:  15,
		Address:   "北京市北京市海淀区45 Chengfu Rd",
		Latitude:  39.995120999999997,
		Longitude: 116.334154,
		Name:      "东升乡人民政府(海淀区成府路45号)",
	}))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced location sharing capabilities with methods to send and retrieve location information.
	- Added a new `Location` structure to manage location-related data such as accuracy, address, latitude, longitude, and name.
- **Refactor**
	- Enhanced the `Say` method for greater flexibility in message types, including support for location messages.
- **Style**
	- Updated indentation in the `UrlLinkPayload` structure for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->