### PR TITLE
feat(message): support refer msg

### DIFF
--- a/wechaty-puppet/puppet.go
+++ b/wechaty-puppet/puppet.go
@@ -3,7 +3,9 @@ package wechatypuppet
 import (
 	"errors"
 	"fmt"
+
 	lru "github.com/hashicorp/golang-lru"
+
 	"github.com/wechaty/go-wechaty/wechaty-puppet/events"
 	"github.com/wechaty/go-wechaty/wechaty-puppet/filebox"
 	"github.com/wechaty/go-wechaty/wechaty-puppet/helper"

--- a/wechaty-puppet/schemas/message.go
+++ b/wechaty-puppet/schemas/message.go
@@ -93,6 +93,18 @@ type MessagePayloadBase struct {
 
 	// 小程序有些消息类型，wechaty服务端解析不处理，框架端解析。 xml type 36 是小程序
 	FixMiniApp bool
+
+	ReferMessage *ReferMessagePayload
+}
+
+type ReferMessagePayload struct {
+	Type        MessageType // TODO： 确认是否和 MessageType 一致
+	SourceMsgId string
+	TalkerId    string
+	RoomId      string
+	DisplayName string
+	Content     string
+	Timestamp   time.Time
 }
 
 type MessagePayloadRoom struct {

--- a/wechaty-puppet/schemas/message.go
+++ b/wechaty-puppet/schemas/message.go
@@ -97,9 +97,10 @@ type MessagePayloadBase struct {
 	ReferMessage *ReferMessagePayload
 }
 
+// ReferMessagePayload refer message payload
 type ReferMessagePayload struct {
 	Type        MessageType // TODO： 确认是否和 MessageType 一致
-	SourceMsgId string
+	SourceMsgID string
 	TalkerId    string
 	RoomId      string
 	DisplayName string

--- a/wechaty/user/message.go
+++ b/wechaty/user/message.go
@@ -147,8 +147,14 @@ func (m *Message) Date() time.Time {
 	return m.payload.Timestamp
 }
 
+// ReferMessage get the refer message
 func (m *Message) ReferMessage() *schemas.ReferMessagePayload {
-	return &(*m.payload.ReferMessage) // 不希望能被修改原数据
+	if m.payload.ReferMessage == nil {
+		return nil
+	}
+	
+	copy := *m.payload.ReferMessage
+	return &copy
 }
 
 // Say reply a Text or Media File message to the sender.

--- a/wechaty/user/message.go
+++ b/wechaty/user/message.go
@@ -147,6 +147,10 @@ func (m *Message) Date() time.Time {
 	return m.payload.Timestamp
 }
 
+func (m *Message) ReferMessage() *schemas.ReferMessagePayload {
+	return &(*m.payload.ReferMessage) // 不希望能被修改原数据
+}
+
 // Say reply a Text or Media File message to the sender.
 // Support msg:
 // string


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Added support for message referencing in Wechaty, allowing retrieval of referenced message details via new `ReferMessage` field and method.
> 
>   - **New Features**:
>     - Added `ReferMessage` field to `MessagePayloadBase` in `schemas/message.go` to support message referencing.
>     - Introduced `ReferMessagePayload` struct in `schemas/message.go` to store referenced message details.
>     - Added `ReferMessage()` method to `Message` class in `user/message.go` to retrieve referenced message details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=wechaty%2Fgo-wechaty&utm_source=github&utm_medium=referral)<sup> for c47fe4fc10d748c19cb28cf7c09ab807dcacd25f. You can [customize](https://app.ellipsis.dev/wechaty/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for referencing detailed information about another message within a message, allowing users to view metadata of referenced messages.
  - Introduced a method to retrieve referenced message details from a message instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->